### PR TITLE
Add rpc whitelist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
           docker pull ${{ needs.build.outputs.IMAGE }}
           docker tag ${{ needs.build.outputs.IMAGE }} bitcoin-core-docker
       - uses: actions/checkout@v4
-      - run: ./examples/${CONTAINER_NAME}.sh
+      - name: Start ${{ env.CONTAINER_NAME }}
+        run: ./examples/${CONTAINER_NAME}.sh
       - name: Wait for healthy
         run: |
           while ! docker exec -i ${CONTAINER_NAME} /opt/wallet-health.sh; do
@@ -103,3 +104,5 @@ jobs:
             echo "Last log: $(docker logs -n1 ${CONTAINER_NAME})"
             sleep 15
           done
+      - name: Ensure default user works with whitelist
+        run: docker exec ${CONTAINER_NAME} bitcoin-cli -rpcuser=default -rpcpassword=default getblockcount

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye-slim
 
 RUN apt-get update -y \
-  && apt-get install -y curl procps procps jq \
+  && apt-get install -y curl procps procps jq xxd \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/examples/testnet4.sh
+++ b/examples/testnet4.sh
@@ -5,6 +5,8 @@ docker run -d \
   -e CHAIN=testnet4 \
   -e RPC_USER=default \
   -e RPC_PASSWORD=default \
+  -e ADMIN_RPC_USER=admin \
+  -e ADMIN_RPC_PASSWORD=admin \
   -e WALLET_NAME=default \
   -e WALLET_ADDRESS=tb1qfm8a8pxer0kmfa4xlk34e44xpr8g46ae0v04dw \
   bitcoin-core-docker /opt/wallet.sh

--- a/wallet.sh
+++ b/wallet.sh
@@ -12,7 +12,7 @@ generate_rpcauth_entry() {
   local salt
   local hashed_password
   salt=$(head -c 16 /dev/urandom | xxd -ps | tr -d '\n')
-  hashed_password=$(echo -n "${password}${salt}" | sha256sum | awk '{print $1}')
+  hashed_password=$(echo -n "${password}" | openssl dgst -sha256 -hmac "${salt}" -binary | xxd -p -c 64)
   
   echo "rpcauth=${user}:${salt}\$${hashed_password}"
 }


### PR DESCRIPTION
Limit the rpc user to only functionality required by zetaclient. Add separate admin user that is exempt from whitelist.

This prevents rpc users from reconfiguring the wallets or using other privileged functionality.

Related to https://github.com/zeta-chain/argo-cd-apps/issues/451